### PR TITLE
Live Telescope Theme Switcher 

### DIFF
--- a/lua/telescope/_extensions/themes.lua
+++ b/lua/telescope/_extensions/themes.lua
@@ -1,0 +1,103 @@
+local has_telescope, telescope = pcall(require, "telescope")
+if not has_telescope then
+  error("themer.lua requires nvim-telescope/telescope.nvim")
+end
+local actions = require("telescope.actions")
+local action_state = require("telescope.actions.state")
+local pickers = require("telescope.pickers")
+local finders = require("telescope.finders")
+
+-- Get Dir Info
+local function scandir(directory)
+  local i, t, popen = 0, {}, io.popen
+  local pfile = popen('ls -a "' .. directory .. '"')
+  for filename in pfile:lines() do
+    i = i + 1
+    t[i] = filename
+  end
+  pfile:close()
+  return t
+end
+
+local function get_theme()
+  local themes = {}
+  local theme_dir = vim.fn.stdpath("data") .. "/site/pack/packer/opt/themer.lua/colors/"
+
+  local fd = scandir(theme_dir)
+  if fd then
+    for _, file in ipairs(fd) do
+      if string.find(file, "lua") then
+        table.insert(themes, (file:gsub(theme_dir, ""):gsub(".lua", "")))
+      end
+    end
+  end
+  return themes
+end
+
+local function enter(prompt_bufnr)
+  local selected = action_state.get_selected_entry()
+  local cmd = "colorscheme " .. selected[1]
+  vim.cmd(cmd)
+  local colorscheme = "vim.cmd([[colorscheme " .. " " .. selected[1] .. "]])"
+  vim.fn.jobstart(colorscheme)
+  actions.close(prompt_bufnr)
+end
+
+local function next_color(prompt_bufnr)
+  actions.move_selection_next(prompt_bufnr)
+  local selection = action_state.get_selected_entry()
+  local cmd = "colorscheme " .. selection[1]
+  vim.cmd(cmd)
+end
+
+local function prev_color(prompt_bufnr)
+  actions.move_selection_previous(prompt_bufnr)
+  local selection = action_state.get_selected_entry()
+  local cmd = "colorscheme " .. selection[1]
+  vim.cmd(cmd)
+end
+
+local function preview(prompt_bufnr)
+  local selection = action_state.get_selected_entry()
+  local cmd = "colorscheme " .. selection[1]
+  vim.cmd(cmd)
+end
+
+local function themer(opts)
+  local colors = get_theme()
+  local opts = require("telescope.themes").get_dropdown({
+    prompt_title = "Themer ColorScheme",
+    results_title = "Change colorscheme",
+    finder = finders.new_table({
+      results = colors,
+    }),
+    previewer = false,
+    attach_mappings = function(prompt_bufnr, map)
+      for type, value in pairs(require("themer.config")("get").telescope_mappings) do
+        for bind, method in pairs(value) do
+          map(type, bind, function()
+            if method == "enter" then
+              enter(prompt_bufnr)
+            elseif method == "next_color" then
+              next_color(prompt_bufnr)
+            elseif method == "prev_color" then
+              prev_color(prompt_bufnr)
+            elseif method == "preview" then
+              preview(prompt_bufnr)
+            end
+          end)
+        end
+      end
+      return true
+    end,
+    sorter = require("telescope.config").values.generic_sorter({}),
+  })
+  local colorschemes = pickers.new(opts)
+  colorschemes:find()
+end
+
+return telescope.register_extension({
+  exports = {
+    themes = themer,
+  },
+})

--- a/lua/themer/config.lua
+++ b/lua/themer/config.lua
@@ -1,89 +1,90 @@
 local options = {
-    colorscheme = "rose_pine", -- default colorscheme
-    transparent = false,
-    term_colors = true,
-    dim_inactive = false,
-    styles = {
-        heading = {
-            h1 = {},
-            h2 = {},
-        },
-        ["function"] = {},
-        functionBuiltIn = {},
-        variable = {},
-        variableBuiltIn = {},
-        include = {},
-        identifier = {},
-        keyword = {},
-        keywordBuiltIn = {},
-        struct = {},
-        string = {},
-        parameter = {},
-        field = {},
-        type = {},
-        typeBuiltIn = {},
-        property = {},
-        comment = {},
-        punctuation = {},
-        constructor = {},
-        operator = {},
-        constant = {},
-        constantBuiltIn = {},
-        todo = {},
-        character = {},
-        conditional = {},
-        number = {},
-        statement = {},
-        uri = {},
-        diagnostic = {
-            underline = {
-                error = {},
-                warn = {},
-                info = {},
-                hint = {},
-            },
-            virtual_text = {
-                error = {},
-                warn = {},
-                info = {},
-                hint = {},
-            },
-        },
+  colorscheme = "rose_pine", -- default colorscheme
+  transparent = false,
+  term_colors = true,
+  dim_inactive = false,
+  telescope_mappings = {},
+  styles = {
+    heading = {
+      h1 = {},
+      h2 = {},
     },
-    remaps = {
-        palette = {},
-        -- per colorscheme palette remaps, for example:
-        -- remaps.palette = {
-        --     rose_pine = {
-        --     	fg = "#000000"
-        --     }
-        -- },
-        -- would recommend to look into vim.api.nvim_set_hl() docs before using this
-        -- remaps.highlights = {
-        --     rose_pine = {
-        --     	Normal = { bg = "#000000" }
-        --     }
-        -- },
-        --
-        -- Also you can do remaps.highlights.globals  for global highlight remaps
-        highlights = {},
+    ["function"] = {},
+    functionBuiltIn = {},
+    variable = {},
+    variableBuiltIn = {},
+    include = {},
+    identifier = {},
+    keyword = {},
+    keywordBuiltIn = {},
+    struct = {},
+    string = {},
+    parameter = {},
+    field = {},
+    type = {},
+    typeBuiltIn = {},
+    property = {},
+    comment = {},
+    punctuation = {},
+    constructor = {},
+    operator = {},
+    constant = {},
+    constantBuiltIn = {},
+    todo = {},
+    character = {},
+    conditional = {},
+    number = {},
+    statement = {},
+    uri = {},
+    diagnostic = {
+      underline = {
+        error = {},
+        warn = {},
+        info = {},
+        hint = {},
+      },
+      virtual_text = {
+        error = {},
+        warn = {},
+        info = {},
+        hint = {},
+      },
     },
+  },
+  remaps = {
+    palette = {},
+    -- per colorscheme palette remaps, for example:
+    -- remaps.palette = {
+    --     rose_pine = {
+    --     	fg = "#000000"
+    --     }
+    -- },
+    -- would recommend to look into vim.api.nvim_set_hl() docs before using this
+    -- remaps.highlights = {
+    --     rose_pine = {
+    --     	Normal = { bg = "#000000" }
+    --     }
+    -- },
+    --
+    -- Also you can do remaps.highlights.globals  for global highlight remaps
+    highlights = {},
+  },
 
-    langs = {
-        html = true,
-        md = true,
-    },
+  langs = {
+    html = true,
+    md = true,
+  },
 
-    plugins = {
-        treesitter = true,
-        indentline = true,
-        barbar = true,
-        bufferline = true,
-        cmp = true,
-        gitsigns = true,
-        lsp = true,
-        telescope = true,
-    },
+  plugins = {
+    treesitter = true,
+    indentline = true,
+    barbar = true,
+    bufferline = true,
+    cmp = true,
+    gitsigns = true,
+    lsp = true,
+    telescope = true,
+  },
 }
 
 --- internal: iterate given options over the default config (for internal purposes)
@@ -92,12 +93,12 @@ local options = {
 --- @param type string
 --- @param opts table
 return function(type, opts)
-    if type == "get" then
-        return options
-    elseif type == "internal" then
-        options = vim.tbl_deep_extend("force", options, opts or {})
-    elseif type == "user" then
-        options = vim.tbl_deep_extend("force", options, opts or {})
-        require("themer.modules.core")(options.colorscheme)
-    end
+  if type == "get" then
+    return options
+  elseif type == "internal" then
+    options = vim.tbl_deep_extend("force", options, opts or {})
+  elseif type == "user" then
+    options = vim.tbl_deep_extend("force", options, opts or {})
+    require("themer.modules.core")(options.colorscheme)
+  end
 end


### PR DESCRIPTION
Live Colour Scheme Switcher for theme : 
```:Telescope themes```

Default Configs would have to be added to readme : 

```lua
    telescope_mappings = { 
      ["n"] = { 
        ["<CR>"] = "enter",
        ["k"] = "prev_color",
        ["j"] = "next_color",
        ["p"] = "preview"
      },
      ["i"] = { 
        ["<CR>"] = "enter",
        ["<S-Tab>"] = "prev_color",
        ["<Tab>"] = "next_color",
        ["<C-p>"] = "preview",
      },
    },
  require("telescope").load_extension("themes")

```