### PR TITLE
Fix LineNr for jellybeans

### DIFF
--- a/lua/themer/modules/themes/jellybeans.lua
+++ b/lua/themer/modules/themes/jellybeans.lua
@@ -55,4 +55,7 @@ return {
   ["fg"] = "#e8e8d3",
   ["blue"] = "#7aa2f7",
   ["diff"] = { ["add"] = "#437019", ["text"] = "#0", ["change"] = "#2b5b77", ["remove"] = "#700009" },
+  ["remaps"] = {
+    LineNr = "#606060",
+  },
 }


### PR DESCRIPTION
`LineNr` now is mapping to `ThemerSubtle`, which on jellybeans is a
very light white color. Change it to the correct one.