### PR TITLE
Partial fixes for jellybeans theme

### DIFF
--- a/lua/themer/modules/themes/jellybeans.lua
+++ b/lua/themer/modules/themes/jellybeans.lua
@@ -57,7 +57,9 @@ return {
   ["diff"] = { ["add"] = "#437019", ["text"] = "#0", ["change"] = "#2b5b77", ["remove"] = "#700009" },
   ["remaps"] = {
     ["base"] = {
+      ["ColorColumn"] = { bg = "#000000" },
       ["LineNr"] = { fg = "#606060" },
+      ["Visual"] = { bg = "#404040" },
     },
   },
 }


### PR DESCRIPTION

These changes align the theme here with the one "nanotech/jellybeans.vim".

 - ColumnColumn is now a more subtle black
 - Visual selections are now visible

There are still some differences with this this theme. I'm new to theme patching
so I'm not sure how to fix these:

 - `jellybeans.vim` highlights invalid jsdoc in red. This theme doesn't highlight that at all.
 - `jellybeans.vim` highlights the left gutter (SignColumn?). This theme doesn't highlight it.
