### PR TITLE
WIP: Remove default reverse for IncSearch hightlight group

### DIFF
--- a/lua/themer/modules/core/mapper.lua
+++ b/lua/themer/modules/core/mapper.lua
@@ -64,6 +64,9 @@ local function get_base(cp)
   cp.bg.base = config.transparent and "NONE" or cp.bg.base
   cp.bg.alt = config.transparent and "NONE" or cp.bg.alt
 
+  -- Remove IncSearch reverse as default
+  cp.inc_search.style = "NONE"
+
   cp.gitsigns = cp.gitsigns or cp.diff
 
   local groups = remap_styles(cp)


### PR DESCRIPTION
Vim default IncSearch group defines gui="reverse" in order to have one group for the search and one group for the incremental search, the latter will have the colors swapped to be recognizable.

themer.lua should remove such default as in the configuration it clearly says `fg` and `bg` for the `inc_search` group, so one to have the correct visualization has to swap the foreground and background.

BREAKING_CHANGE(inc_search): swap `fg` and `bg` in `inc_search` group