### PR TITLE
feat(mapper): add config.diagnostic_underline

### DIFF
--- a/lua/themer/modules/core/mapper.lua
+++ b/lua/themer/modules/core/mapper.lua
@@ -38,11 +38,10 @@ local function remap_styles(cp)
     uri = { fg = cp.uri, style = "underline" },
     diagnostic = {
       underline = {
-
-        error = { fg = cp.diagnostic.error, style = "undercurl" },
-        warn = { fg = cp.diagnostic.warn, style = "undercurl" },
-        info = { fg = cp.diagnostic.info, style = "undercurl" },
-        hint = { fg = cp.diagnostic.hint, style = "undercurl" },
+        error = { fg = cp.diagnostic.error, style = config.diagnostic_underline or "undercurl" },
+        warn = { fg = cp.diagnostic.warn, style = config.diagnostic_underline or "undercurl" },
+        info = { fg = cp.diagnostic.info, style = config.diagnostic_underline or "undercurl" },
+        hint = { fg = cp.diagnostic.hint, style = config.diagnostic_underline or "undercurl" },
       },
       virtual_text = {
         error = { fg = cp.diagnostic.error, style = "italic" },


### PR DESCRIPTION
Mostly personal preference, but I prefer a straight line instead of the curly one for the diagnostic, I wanted to change it to do so but I saw there was no way to do so.

This PR adds `diagnostic_underline` to the config table so it'll work across themes.

This should not break any configuration as I've put the old values as default.