### PR TITLE
fix: remaps.palette.globals and sonokai-deep treesitter highlight groups

### DIFF
--- a/lua/themer/modules/core/api.lua
+++ b/lua/themer/modules/core/api.lua
@@ -21,7 +21,7 @@ If this is a bug, report it at https://github.com/narutoxy/themer.lua]],
     return false
   end
 
-  if not (next(remaps or remaps_global) == nil) then
+  if not (next(remaps) == nil and next(remaps_global) == nil) then
     return vim.tbl_deep_extend("force", csc, remaps_global, remaps)
   else
     return csc

--- a/lua/themer/modules/themes/sonokai_deep.lua
+++ b/lua/themer/modules/themes/sonokai_deep.lua
@@ -115,7 +115,7 @@ cp.remaps = {
     },
 
     treesitter = {
-      TSSymbol = { fg = colors.lBlue },
+      ["@symbol"] = { link = "ThemerType" },
     },
 
     telescope = {


### PR DESCRIPTION
Since treesitter removed the support for old TS* highlight groups, the `sonokai-deep` theme has an invalid remap.

When I tried fix it locally by the config table, I noticed the config `remaps.palette.globals` was not working because of the way it was being checked. So I fixed it too in this PR.